### PR TITLE
Add link to operator readme for operator tutorial section

### DIFF
--- a/Kubernetes-basic-tutorial.md
+++ b/Kubernetes-basic-tutorial.md
@@ -127,5 +127,4 @@ rajas@node-0:~$
 
 # Kubernetes Operators 
 
-1. Download go wget https://go.dev/dl/go1.23.0.linux-amd64.tar.gz and place it in /usr/src 
-2. set GOPATH, GOROOT, 
+Check instructions in [the README under our lab's DeathStarBench fork](https://github.com/docc-lab/DeathStarBench/tree/operator/hotelReservation/k8s-operator/frontservices-operator)


### PR DESCRIPTION
Per [Raja's request](https://github.com/docc-lab/DeathStarBench/issues/1#issue-2476819238), add link of operator instructions in readme to this tutorial.
I don't have write permission in this repo so create an PR instead.